### PR TITLE
Exclude autoblocks from weekly schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "America/Chicago",
-  "extends": ["group:all", "schedule:weekly"],
-  "reviewers": ["team:engineering"]
+  "reviewers": ["team:engineering"],
+  "packageRules": [
+    {
+      "groupName": "all non-major dependencies",
+      "matchPackagePatterns": ["*"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "extends": ["schedule:weekly"],
+      "excludePackagePrefixes": ["@autoblocks/"],
+      "excludePackageNames": ["autoblocksai"]
+    }
+  ]
 }


### PR DESCRIPTION
I think this will allow updates to the SDKs right away while still keeping everything else on a weekly schedule. Also gonna make major updates separately